### PR TITLE
Show deprecation warnings for twingly-analytics

### DIFF
--- a/lib/twingly-analytics.rb
+++ b/lib/twingly-analytics.rb
@@ -4,3 +4,5 @@ require 'twingly-analytics/result'
 require 'twingly-analytics/parser'
 require 'twingly-analytics/post'
 require 'twingly-analytics/version'
+
+warn "[DEPRECATION] This gem has been renamed to twingly-search and will no longer be supported."

--- a/lib/twingly-analytics/version.rb
+++ b/lib/twingly-analytics/version.rb
@@ -1,5 +1,5 @@
 module Twingly
   module Analytics
-    VERSION = "2.0.1"
+    VERSION = "2.0.2"
   end
 end

--- a/twingly-analytics-api-ruby.gemspec
+++ b/twingly-analytics-api-ruby.gemspec
@@ -19,6 +19,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.post_install_message = <<-MESSAGE
+!    The 'twingly-analytics' gem has been deprecated and has been replaced by 'twingly-search'.
+!    See: https://rubygems.org/gems/twingly-search
+!    And: https://github.com/twingly/twingly-search-api-ruby
+MESSAGE
+
   spec.add_dependency "faraday",  ['>= 0.9.2', '< 0.10']
   spec.add_dependency "nokogiri", "~> 1.0"
   spec.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
Show deprecation warnings when installing an requiring.

Related to #24