### PR TITLE
Handle non-XML responses from server

### DIFF
--- a/lib/twingly/search/parser.rb
+++ b/lib/twingly/search/parser.rb
@@ -17,6 +17,12 @@ module Twingly
         data_node = nokogiri.at_xpath('/twinglydata')
         handle_non_xml_document(nokogiri) unless data_node
 
+        create_result(data_node)
+      end
+
+      private
+
+      def create_result(data_node)
         result = Result.new
         result.number_of_matches_returned = data_node.attribute('numberOfMatchesReturned').value.to_i
         result.number_of_matches_total    = data_node.attribute('numberOfMatchesTotal').value.to_i
@@ -28,8 +34,6 @@ module Twingly
 
         result
       end
-
-      private
 
       def parse_post(element)
         post_params = {}

--- a/lib/twingly/search/parser.rb
+++ b/lib/twingly/search/parser.rb
@@ -14,12 +14,15 @@ module Twingly
         failure = nokogiri.at_xpath('//name:blogstream/name:operationResult[@resultType="failure"]', name: 'http://www.twingly.com')
         handle_failure(failure) if failure
 
-        result = Result.new
-        result.number_of_matches_returned = nokogiri.at_xpath('/twinglydata/@numberOfMatchesReturned').value.to_i
-        result.number_of_matches_total = nokogiri.at_xpath('/twinglydata/@numberOfMatchesTotal').value.to_i
-        result.seconds_elapsed = nokogiri.at_xpath('/twinglydata/@secondsElapsed').value.to_f
+        data_node = nokogiri.at_xpath('/twinglydata')
+        handle_non_xml_document(nokogiri) unless data_node
 
-        nokogiri.xpath('//post').each do |post|
+        result = Result.new
+        result.number_of_matches_returned = data_node.attribute('numberOfMatchesReturned').value.to_i
+        result.number_of_matches_total    = data_node.attribute('numberOfMatchesTotal').value.to_i
+        result.seconds_elapsed            = data_node.attribute('secondsElapsed').value.to_f
+
+        data_node.xpath('//post').each do |post|
           result.posts << parse_post(post)
         end
 
@@ -50,6 +53,11 @@ module Twingly
 
       def handle_failure(failure)
         fail Error.from_api_response_message(failure.text)
+      end
+
+      def handle_non_xml_document(document)
+        response_text = document.search('//text()').map(&:text)
+        fail ServerError, response_text
       end
     end
   end

--- a/spec/fixtures/non_xml_result.xml
+++ b/spec/fixtures/non_xml_result.xml
@@ -1,0 +1,3 @@
+<html><body><h1>503 Service Unavailable</h1>
+No server is available to handle this request.
+</body></html>

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -45,5 +45,13 @@ describe Parser do
         expect { subject }.to raise_error(ServerError)
       end
     end
+
+    context "with a undefined error result" do
+      let(:document) { Fixture.get(:non_xml) }
+
+      it "should raise ServerError" do
+        expect { subject }.to raise_error(ServerError, /503 Service Unavailable/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Decided to handle non-XML responses inside the parser (instead of
in the client) since all other errors are handled there.

fix #31