### PR TITLE
Use require_relative

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
   - jruby-9.0.0.0
 deploy:
   provider: rubygems

--- a/lib/twingly/search.rb
+++ b/lib/twingly/search.rb
@@ -1,7 +1,7 @@
-require 'twingly/search/version'
-require 'twingly/search/error'
-require 'twingly/search/client'
-require 'twingly/search/query'
-require 'twingly/search/result'
-require 'twingly/search/parser'
-require 'twingly/search/post'
+require_relative "search/version"
+require_relative "search/error"
+require_relative "search/client"
+require_relative "search/query"
+require_relative "search/result"
+require_relative "search/parser"
+require_relative "search/post"


### PR DESCRIPTION
To be able to load from the working directory when starting pry,
even if you have the gem installed.

    dotenv pry -r ./lib/twingly/search.rb

is really useful.