### PR TITLE
Automatically convert Query#start_time and #end_time to UTC

### DIFF
--- a/lib/twingly/search/query.rb
+++ b/lib/twingly/search/query.rb
@@ -1,4 +1,5 @@
 require "faraday"
+require "time"
 
 module Twingly
   module Search

--- a/lib/twingly/search/query.rb
+++ b/lib/twingly/search/query.rb
@@ -7,12 +7,13 @@ module Twingly
     # @attr [String] pattern the search query.
     # @attr [String] language which language to restrict the query to.
     # @attr [Client] client the client that this query is connected to.
-    # @attr [Time, #to_time] start_time search for posts published after
+    # @attr_reader [Time] start_time search for posts published after
     #   this time (inclusive).
-    # @attr [Time, #to_time] end_time search for posts published before
+    # @attr_reader [Time] end_time search for posts published before
     #   this time (inclusive).
     class Query
-      attr_accessor :pattern, :language, :client, :start_time, :end_time
+      attr_accessor :pattern, :language, :client
+      attr_reader   :start_time, :end_time
 
       # No need to call this method manually, instead use {Client#query}.
       #
@@ -56,14 +57,30 @@ module Twingly
         }
       end
 
+      # Search for posts published after this time (inclusive).
+      #
+      # @param [Time, #to_time] time an instance of the Time class
+      #   or an object responding to #to_time.
+      def start_time=(time)
+        @start_time = time.to_time.utc
+      end
+
+      # Search for posts published before this time (inclusive).
+      #
+      # @param [Time, #to_time] time an instance of the Time class
+      #   or an object responding to #to_time.
+      def end_time=(time)
+        @end_time = time.to_time.utc
+      end
+
       private
 
       def ts
-        start_time.to_time.strftime("%F %T") if start_time
+        start_time.strftime("%F %T") if start_time
       end
 
       def ts_to
-        end_time.to_time.strftime("%F %T") if end_time
+        end_time.strftime("%F %T") if end_time
       end
     end
   end

--- a/lib/twingly/search/query.rb
+++ b/lib/twingly/search/query.rb
@@ -8,13 +8,18 @@ module Twingly
     # @attr [String] pattern the search query.
     # @attr [String] language which language to restrict the query to.
     # @attr [Client] client the client that this query is connected to.
-    # @attr_reader [Time] start_time search for posts published after
-    #   this time (inclusive).
-    # @attr_reader [Time] end_time search for posts published before
-    #   this time (inclusive).
     class Query
       attr_accessor :pattern, :language, :client
-      attr_reader   :start_time, :end_time
+
+      # @return [Time] the time that was set with {#start_time=}, converted to UTC.
+      def start_time
+        @start_time
+      end
+
+      # @return [Time] the time that was set with {#end_time=}, converted to UTC.
+      def end_time
+        @end_time
+      end
 
       # No need to call this method manually, instead use {Client#query}.
       #

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -77,7 +77,7 @@ describe Query do
     end
 
     context "when given time in UTC" do
-      let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+00:00") }
+      let(:time) { Time.parse("2016-02-09 09:01:22 UTC") }
 
       it "should not change timezone" do
         expect(subject.start_time.utc?).to be(true)
@@ -86,7 +86,7 @@ describe Query do
     end
 
     context "when given time not in UTC" do
-      let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+05:00") }
+      let(:time) { Time.parse("2016-02-09 09:01:22 +05:00") }
 
       it "should convert to UTC" do
         expect(subject.start_time.utc?).to be(true)
@@ -106,7 +106,7 @@ describe Query do
     end
 
     context "when given time in UTC" do
-      let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+00:00") }
+      let(:time) { Time.parse("2016-02-09 09:01:22 UTC") }
 
       it "should not change timezone" do
         expect(subject.end_time.utc?).to be(true)
@@ -115,7 +115,7 @@ describe Query do
     end
 
     context "when given time not in UTC" do
-      let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+05:00") }
+      let(:time) { Time.parse("2016-02-09 09:01:22 +05:00") }
 
       it "should convert to UTC" do
         expect(subject.end_time.utc?).to be(true)
@@ -137,7 +137,7 @@ describe Query do
     end
 
     it "should encode url paramters" do
-      subject.end_time = Time.new(2013, 12, 28, 9, 01, 22, "+00:00")
+      subject.end_time = Time.parse("2013-12-28 09:01:22 UTC")
       expect(subject.url_parameters).to include('tsTo=2013-12-28+09%3A01%3A22')
     end
   end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -70,6 +70,60 @@ describe Query do
     end
   end
 
+  describe "#start_time=" do
+    before do
+      subject.pattern    = "semla"
+      subject.start_time = time
+    end
+
+    context "when given time in UTC" do
+      let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+00:00") }
+
+      it "should not change timezone" do
+        expect(subject.request_parameters).to include(ts: "2016-02-09 09:01:22")
+      end
+    end
+
+    context "when given time not in UTC" do
+      let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+05:00") }
+
+      it "should convert to UTC" do
+        expect(subject.request_parameters).to include(ts: "2016-02-09 04:01:22")
+      end
+
+      it "should not modify the given time object" do
+        expect(subject.start_time).not_to equal(time)
+      end
+    end
+  end
+
+  describe "#end_time=" do
+    before do
+      subject.pattern  = "semla"
+      subject.end_time = time
+    end
+
+    context "when given time in UTC" do
+      let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+00:00") }
+
+      it "should not change timezone" do
+        expect(subject.request_parameters).to include(tsTo: "2016-02-09 09:01:22")
+      end
+    end
+
+    context "when given time not in UTC" do
+      let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+05:00") }
+
+      it "should convert to UTC" do
+        expect(subject.request_parameters).to include(tsTo: "2016-02-09 04:01:22")
+      end
+
+      it "should not modify the given time object" do
+        expect(subject.end_time).not_to equal(time)
+      end
+    end
+  end
+
   context "with valid pattern" do
     before { subject.pattern = "christmas" }
 
@@ -78,18 +132,8 @@ describe Query do
       expect(subject.request_parameters).to include(documentlang: 'en')
     end
 
-    it "should add start_time" do
-      subject.start_time = Time.new(2012, 12, 28, 9, 01, 22)
-      expect(subject.request_parameters).to include(ts: '2012-12-28 09:01:22')
-    end
-
-    it "should add end_time" do
-      subject.end_time = Time.new(2013, 12, 28, 9, 01, 22)
-      expect(subject.request_parameters).to include(tsTo: '2013-12-28 09:01:22')
-    end
-
     it "should encode url paramters" do
-      subject.end_time = Time.new(2013, 12, 28, 9, 01, 22)
+      subject.end_time = Time.new(2013, 12, 28, 9, 01, 22, "+00:00")
       expect(subject.url_parameters).to include('tsTo=2013-12-28+09%3A01%3A22')
     end
   end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -80,6 +80,7 @@ describe Query do
       let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+00:00") }
 
       it "should not change timezone" do
+        expect(subject.start_time.utc?).to be(true)
         expect(subject.request_parameters).to include(ts: "2016-02-09 09:01:22")
       end
     end
@@ -88,6 +89,7 @@ describe Query do
       let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+05:00") }
 
       it "should convert to UTC" do
+        expect(subject.start_time.utc?).to be(true)
         expect(subject.request_parameters).to include(ts: "2016-02-09 04:01:22")
       end
 
@@ -107,6 +109,7 @@ describe Query do
       let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+00:00") }
 
       it "should not change timezone" do
+        expect(subject.end_time.utc?).to be(true)
         expect(subject.request_parameters).to include(tsTo: "2016-02-09 09:01:22")
       end
     end
@@ -115,6 +118,7 @@ describe Query do
       let(:time) { Time.new(2016, 2, 9, 9, 01, 22, "+05:00") }
 
       it "should convert to UTC" do
+        expect(subject.end_time.utc?).to be(true)
         expect(subject.request_parameters).to include(tsTo: "2016-02-09 04:01:22")
       end
 


### PR DESCRIPTION
Noticed that the documentation above `start_time=` does not show up in the yard documentation, but at least its documented in the code. Found an issue on yard for that: https://github.com/lsegal/yard/issues/516 but it doesn't look as it will be fixed :(

close #43