### PR TITLE
Use any rake 11 version

### DIFF
--- a/twingly-search-api-ruby.gemspec
+++ b/twingly-search-api-ruby.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1"
   spec.add_development_dependency "vcr", "~> 2.6"
   spec.add_development_dependency "webmock", "~> 1.0"
-  spec.add_development_dependency "rake", "~> 0"
+  spec.add_development_dependency "rake", "~> 11"
   spec.add_development_dependency "yard", "~> 0.8"
 end


### PR DESCRIPTION
0.9.6 is quite old, from 2012: https://rubygems.org/gems/rake/versions