### PR TITLE
Drop support for old Ruby versions (1.9.3 and 2.0.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ before_install:
   - gem update bundler
 cache: bundler
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To learn more about the capabilities of the API, please read the [Twingly Search
 
 * API key, [sign up](https://www.twingly.com/try-for-free) via [twingly.com](https://www.twingly.com/) to get one
 * Ruby
-  * Ruby 1.9, 2.0, 2.1, 2.2, 2.3
+  * Ruby 2.1, 2.2, 2.3
   * JRuby 9000
 
 ## Development

--- a/twingly-search-api-ruby.gemspec
+++ b/twingly-search-api-ruby.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Ruby API client for Twingly Search"
   spec.description   = "Twingly Search is a product from Twingly AB"
   spec.license       = 'MIT'
-  spec.required_ruby_version = ">= 1.9.3"
+  spec.required_ruby_version = ">= 2.1.0"
 
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Fixes #61.