### PR TITLE
Include timezone info for timestamps in search query

### DIFF
--- a/lib/twingly/search/query.rb
+++ b/lib/twingly/search/query.rb
@@ -130,7 +130,7 @@ module Twingly
       end
 
       def format_timestamp_for_query(timestamp)
-        timestamp.to_time.utc.strftime("%FT%T")
+        timestamp.to_time.utc.strftime("%FT%TZ")
       end
     end
   end

--- a/lib/twingly/search/query.rb
+++ b/lib/twingly/search/query.rb
@@ -130,7 +130,7 @@ module Twingly
       end
 
       def format_timestamp_for_query(timestamp)
-        timestamp.to_time.utc.strftime("%FT%TZ")
+        timestamp.to_time.utc.iso8601
       end
     end
   end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -91,7 +91,7 @@ describe Query do
       let(:time) { Time.parse(timestamp) }
 
       it "should not change timezone" do
-        expect(subject.request_parameters.fetch(:q)).to include("2016-02-09T09:01:22")
+        expect(subject.request_parameters.fetch(:q)).to include("2016-02-09T09:01:22Z")
       end
 
       it "should not modify the given time object" do
@@ -117,7 +117,7 @@ describe Query do
       let(:time) { Time.parse(timestamp) }
 
       it "should convert to UTC" do
-        expect(subject.request_parameters.fetch(:q)).to include("2016-02-09T04:01:22")
+        expect(subject.request_parameters.fetch(:q)).to include("2016-02-09T04:01:22Z")
       end
 
       it "should not modify the given time object" do
@@ -158,7 +158,7 @@ describe Query do
       let(:time) { Time.parse(timestamp) }
 
       it "should not change timezone" do
-        expect(subject.request_parameters.fetch(:q)).to include("end-date:2016-02-09T09:01:22")
+        expect(subject.request_parameters.fetch(:q)).to include("end-date:2016-02-09T09:01:22Z")
       end
 
       it "should not modify the given time object" do
@@ -184,7 +184,7 @@ describe Query do
       let(:time) { Time.parse(timestamp) }
 
       it "should convert to UTC" do
-        expect(subject.request_parameters.fetch(:q)).to include("end-date:2016-02-09T04:01:22")
+        expect(subject.request_parameters.fetch(:q)).to include("end-date:2016-02-09T04:01:22Z")
       end
 
       it "should not modify the given time object" do
@@ -221,7 +221,7 @@ describe Query do
 
     it "should encode url paramters" do
       subject.end_time = Time.parse("2013-12-28 09:01:22 UTC")
-      expect(subject.url_parameters).to include('end-date%3A2013-12-28T09%3A01%3A22')
+      expect(subject.url_parameters).to include('end-date%3A2013-12-28T09%3A01%3A22Z')
     end
   end
 


### PR DESCRIPTION
Make sure the server knows that all timestamps are in UTC. This needs to be fixed in other API clients as well.