### PR TITLE
Travis for modern Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,9 @@ before_install:
   - gem update bundler
 cache: bundler
 rvm:
-  - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
-  - jruby-9.0.5.0
-  - jruby-9.1.15.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
+  - jruby-9.2.6.0
 notifications:
   email: false


### PR DESCRIPTION
* Ruby 2.4, 2.5 and 2.6 is the current suported versions
* JRuby 9.2 is the current supported version