### PR TITLE
Test with latest Ruby/JRuby versions and drop support for Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ before_install:
 cache: bundler
 matrix:
   include:
-    - rvm: 2.4.9
-    - rvm: 2.5.7
-    - rvm: 2.6.5
-    - rvm: jruby-9.2.9.0
-    - rvm: 2.6.5
+    - rvm: 2.5.8
+    - rvm: 2.6.6
+    - rvm: 2.7.1
+    - rvm: jruby-9.2.11.1
+    - rvm: 2.7.1
       install: true # This skips 'bundle install'
       script: gem build *.gemspec && gem install *.gem
 notifications:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ result.posts # will include all returned posts
 
 * API key, [sign up](https://www.twingly.com/try-for-free) via [twingly.com](https://www.twingly.com/) to get one
 * Ruby
-  * Ruby >= 2.4
+  * Ruby >= 2.5
   * JRuby >= 9.2
 
 ## Development

--- a/twingly-search-api-ruby.gemspec
+++ b/twingly-search-api-ruby.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Ruby API client for Twingly Search"
   spec.description   = "Twingly Search is a product from Twingly AB"
   spec.license       = 'MIT'
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Removed 2.4 as its EOL since 2020-03-31.

https://www.ruby-lang.org/en/downloads/branches/