### PR TITLE
Allow newer versions of Faraday

### DIFF
--- a/twingly-search-api-ruby.gemspec
+++ b/twingly-search-api-ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday",  [">= 0.9.2", "< 1.0"]
+  spec.add_dependency "faraday",  [">= 0.9.2", "< 2.0"]
   spec.add_dependency "nokogiri", "~> 1.0"
   spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rspec-its", "~> 1"


### PR DESCRIPTION
The previous requirement on Faraday < 1.0 prevents us from
updating other gems in our internal projects.

Looking at Faraday's changelog, there seems to be no changes
in 1.0 that would affect this gem negatively.

Faraday's changelog:
https://github.com/lostisland/faraday/blob/master/CHANGELOG.md