### PR TITLE
Run CI on latest Rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5.8, 2.6.6, 2.7.2, 3.0.0, jruby-9.2.13.0]
+        ruby: [2.6.7, 2.7.3, 3.0.1, jruby-9.2.17.0]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Dropping Ruby 2.5 since it's EoL since 2021-03-31.