### PR TITLE
Link to our new API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ To learn more about the features of this gem, read the [gem documentation] or ch
 To learn more about the capabilities of Twingly's APIs, please read the [Blog Search API documentation] and [Blog LiveFeed API documentation].
 
 [gem documentation]: https://www.rubydoc.info/github/twingly/twingly-search-api-ruby
-[Blog Search API documentation]: https://developer.twingly.com/resources/search/
-[Blog LiveFeed API documentation]: https://developer.twingly.com/resources/livefeed/
+[Blog Search API documentation]: https://app.twingly.com/blog_search?tab=documentation
+[Blog LiveFeed API documentation]: https://app.twingly.com/blog_livefeed?tab=documentation
 
 ### Blog Search API
 

--- a/examples/find_all_posts_mentioning_github.rb
+++ b/examples/find_all_posts_mentioning_github.rb
@@ -21,7 +21,7 @@ class SearchPostStream
 
   # Run block for each blog post returned from api.
   # Uses a sliding time-based window to get all results.
-  # @see https://developer.twingly.com/resources/search/#pagination
+  # @see https://app.twingly.com/blog_search?tab=documentation
   def each
     loop do
       result = execute_with_retry

--- a/lib/twingly/livefeed/post.rb
+++ b/lib/twingly/livefeed/post.rb
@@ -28,9 +28,9 @@ module Twingly
     # @attr_reader [String] blog_name the name of the blog
     # @attr_reader [String] blog_url the blog URL
     # @attr_reader [Integer] blog_rank the rank of the blog, based on authority and language.
-    #   See https://developer.twingly.com/resources/ranking/#blogrank
+    #   See https://app.twingly.com/blog_livefeed?tab=documentation
     # @attr_reader [Integer] authority the blog's authority/influence.
-    #   See https://developer.twingly.com/resources/ranking/#authority
+    #   See https://app.twingly.com/blog_livefeed?tab=documentation
     class Post
       attr_reader :id, :author, :url, :title, :text, :location_code,
         :language_code, :coordinates, :links, :tags, :images, :indexed_at,

--- a/lib/twingly/search/post.rb
+++ b/lib/twingly/search/post.rb
@@ -27,9 +27,9 @@ module Twingly
     # @attr_reader [String] blog_name the name of the blog
     # @attr_reader [String] blog_url the blog URL
     # @attr_reader [Integer] blog_rank the rank of the blog, based on authority and language.
-    #   See https://developer.twingly.com/resources/ranking/#blogrank
+    #   See https://app.twingly.com/blog_search?tab=documentation
     # @attr_reader [Integer] authority the blog's authority/influence.
-    #   See https://developer.twingly.com/resources/ranking/#authority
+    #   https://app.twingly.com/blog_search?tab=documentation
     class Post
       attr_reader :id, :author, :url, :title, :text, :location_code,
         :language_code, :coordinates, :links, :tags, :images, :indexed_at,

--- a/lib/twingly/search/result.rb
+++ b/lib/twingly/search/result.rb
@@ -20,7 +20,7 @@ module Twingly
       #   within the maximum allowed query time.
       # @return [false] if all servers responded within the maximum allowed
       #   query time.
-      # @see https://developer.twingly.com/resources/search/#response
+      # @see https://app.twingly.com/blog_search?tab=documentation
       def incomplete?
         @incomplete_result
       end


### PR DESCRIPTION
As the old site, developer.twingly.com, has been shut down. The documentation for all of our APIs are now available (behind login) at https://app.twingly.com instead.